### PR TITLE
Add shopWindow support to see items with the shop verb.

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -1686,7 +1686,7 @@ Thread.new {
 				oc[:start] = 0
 			end
 
-			if current_stream.nil? or stream_handler[current_stream] or (current_stream =~ /^(?:death|logons|thoughts|voln|familiar|assess|ooc)$/)
+			if current_stream.nil? or stream_handler[current_stream] or (current_stream =~ /^(?:death|logons|thoughts|voln|familiar|assess|ooc|shopWindow)$/)
 				SETTINGS_LOCK.synchronize {
 					HIGHLIGHT.each_pair { |regex,colors|
 						pos = 0
@@ -1754,7 +1754,7 @@ Thread.new {
 							window.add_string(text, line_colors)
 							need_update = true
 						end
-					elsif current_stream =~ /^(?:death|logons|thoughts|voln|familiar|assess|ooc)$/
+					elsif current_stream =~ /^(?:death|logons|thoughts|voln|familiar|assess|ooc|shopWindow)$/
 						if window = stream_handler['main']
 							if PRESET[current_stream]
 								line_colors.push(:start => 0, :fg => PRESET[current_stream][0], :bg => PRESET[current_stream][1], :end => text.length)


### PR DESCRIPTION
<pushStream id="shopWindow" />
On the <d cmd='shop'>oak rack</d>, you see:
  <d cmd='shop #84568817 on   #84568805'>some steel knuckles for 12 platinum Kronars</d>
  <d cmd='shop #84568816 on   #84568805'>a steel military fork for 12 platinum Kronars</d>
  <d cmd='shop #84568815 on   #84568805'>a steel bola for 12 platinum Kronars</d>
  <d cmd='shop #84568814 on   #84568805'>a steel thrusting blade for 12 platinum Kronars</d>
  <d cmd='shop #84568813 on   #84568805'>a steel throwing mallet for 12 platinum Kronars</d>
  <d cmd='shop #84568812 on   #84568805'>a steel footman's flail for 12 platinum Kronars</d>
  <d cmd='shop #84568811 on   #84568805'>a steel hurling axe for 12 platinum Kronars</d>
  <d cmd='shop #84568810 on   #84568805'>a steel cutlass for 12 platinum Kronars</d>
  <d cmd='shop #84568809 on   #84568805'>a steel warring axe for 12 platinum Kronars</d>
  <d cmd='shop #84568807 on   #84568805'>a steel nightstick for 12 platinum Kronars</d>
  <d cmd='shop #84568806 on   #84568805'>a steel throwing spike for 10 platinum Kronars</d>
[Type SHOP [GOOD] to see some details about it.]
<popStream id="shopWindow" /><prompt time="1542662402">&gt;</prompt>